### PR TITLE
Add support for TemporalAmount in every() functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>java-timestream</artifactId>
     <description>A set of builders that create streams of java.time objects</description>
     <url>https://github.com/tginsberg/java-timestream</url>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>java-timestream</artifactId>
     <description>A set of builders that create streams of java.time objects</description>
     <url>https://github.com/tginsberg/java-timestream</url>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <issueManagement>

--- a/src/main/java/com/ginsberg/timestream/LocalDateStream.java
+++ b/src/main/java/com/ginsberg/timestream/LocalDateStream.java
@@ -25,13 +25,14 @@
 package com.ginsberg.timestream;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 /**
  * A builder that creates a stream of LocalDate objects.
- *
+ * <p>
  * <pre>
  * {@code
  * // Print all of the LocalDates between now and a year from now, every other day.
@@ -47,8 +48,12 @@ import java.util.function.UnaryOperator;
  * @author Todd Ginsberg (todd@ginsberg.com)
  */
 public class LocalDateStream extends AbstractComparableStream<LocalDate> {
-    private int amount = 1;
+    private long amount = 1;
     private ChronoUnit unit = ChronoUnit.DAYS;
+
+    private LocalDateStream(final LocalDate from) {
+        super(from);
+    }
 
     /**
      * Create a LocalDateStream, starting at LocalDate.now().
@@ -69,10 +74,6 @@ public class LocalDateStream extends AbstractComparableStream<LocalDate> {
         return new LocalDateStream(from);
     }
 
-    private LocalDateStream(final LocalDate from) {
-        super(from);
-    }
-
     /**
      * Set the inclusive end point of the stream, using an absolute LocalDate.
      *
@@ -88,7 +89,7 @@ public class LocalDateStream extends AbstractComparableStream<LocalDate> {
      * Set the inclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in. May not be null.
+     * @param unit   The non-null unit the amount is denominated in. May not be null.
      * @return A non-null LocalDateStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -115,7 +116,7 @@ public class LocalDateStream extends AbstractComparableStream<LocalDate> {
      * Set the exclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null LocalDateStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -132,7 +133,7 @@ public class LocalDateStream extends AbstractComparableStream<LocalDate> {
      * for this builder is 1 Day.
      *
      * @param amount The number of units to use when calculating the next element of the stream.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null LocalDateStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -142,6 +143,23 @@ public class LocalDateStream extends AbstractComparableStream<LocalDate> {
         Objects.requireNonNull(unit);
         this.amount = Math.abs(amount);
         this.unit = unit;
+        LocalDate.now().plus(0, unit); // Fail fast test
+        return this;
+    }
+
+    /**
+     * Set the duration between successive elements produced by the stream. The default
+     * for this builder is 1 Day.
+     *
+     * @param period The interval to use when calculating the next element of the stream.
+     * @return A non-null LocalDateStream.
+     * @throws java.time.temporal.UnsupportedTemporalTypeException if the period is not supported.
+     * @see ChronoUnit
+     */
+    public LocalDateStream every(Period period) {
+        Objects.requireNonNull(period);
+        this.unit = ChronoUnit.DAYS;
+        this.amount = period.get(this.unit);
         LocalDate.now().plus(0, unit); // Fail fast test
         return this;
     }

--- a/src/main/java/com/ginsberg/timestream/LocalDateTimeStream.java
+++ b/src/main/java/com/ginsberg/timestream/LocalDateTimeStream.java
@@ -24,6 +24,7 @@
 
 package com.ginsberg.timestream;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -31,7 +32,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * A builder that creates a stream of LocalDateTime objects.
- *
+ * <p>
  * <pre>
  * {@code
  * // Print all of the LocalDateTimes between now and a day from now, every other minute.
@@ -47,8 +48,12 @@ import java.util.function.UnaryOperator;
  * @author Todd Ginsberg (todd@ginsberg.com)
  */
 public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime> {
-    private int amount = 1;
+    private long amount = 1;
     private ChronoUnit unit = ChronoUnit.SECONDS;
+
+    private LocalDateTimeStream(final LocalDateTime from) {
+        super(from);
+    }
 
     /**
      * Create a LocalDateTimeStream, starting at LocalDateTime.now().
@@ -69,10 +74,6 @@ public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime>
         return new LocalDateTimeStream(from);
     }
 
-    private LocalDateTimeStream(final LocalDateTime from) {
-        super(from);
-    }
-
     /**
      * Set the inclusive end point of the stream, using an absolute LocalDateTime.
      *
@@ -88,7 +89,7 @@ public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime>
      * Set the inclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in. May not be null.
+     * @param unit   The non-null unit the amount is denominated in. May not be null.
      * @return A non-null LocalDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -115,7 +116,7 @@ public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime>
      * Set the exclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null LocalDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -132,7 +133,7 @@ public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime>
      * for this builder is 1 Second.
      *
      * @param amount The number of units to use when calculating the next element of the stream.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null LocalDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -142,6 +143,22 @@ public class LocalDateTimeStream extends AbstractComparableStream<LocalDateTime>
         Objects.requireNonNull(unit);
         this.amount = Math.abs(amount);
         this.unit = unit;
+        return this;
+    }
+
+    /**
+     * Set the duration between successive elements produced by the stream. The default
+     * for this builder is 1 Second.
+     *
+     * @param duration The interval to use when calculating the next element of the stream.
+     * @return A non-null LocalDateTimeStream.
+     * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
+     * @see ChronoUnit
+     */
+    public LocalDateTimeStream every(Duration duration) {
+        Objects.requireNonNull(unit);
+        this.unit = ChronoUnit.SECONDS;
+        this.amount = duration.get(this.unit);
         return this;
     }
 

--- a/src/main/java/com/ginsberg/timestream/YearMonthStream.java
+++ b/src/main/java/com/ginsberg/timestream/YearMonthStream.java
@@ -24,6 +24,7 @@
 
 package com.ginsberg.timestream;
 
+import java.time.Period;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -31,7 +32,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * A builder that creates a stream of YearMonth objects.
- *
+ * <p>
  * <pre>
  * {@code
  * // Print all of the YearMonths between now and a year from now, every other month.
@@ -47,8 +48,12 @@ import java.util.function.UnaryOperator;
  * @author Todd Ginsberg (todd@ginsberg.com)
  */
 public class YearMonthStream extends AbstractComparableStream<YearMonth> {
-    private int amount = 1;
+    private long amount = 1;
     private ChronoUnit unit = ChronoUnit.MONTHS;
+
+    private YearMonthStream(final YearMonth from) {
+        super(from);
+    }
 
     /**
      * Create a YearMonthStream, starting at YearMonth.now().
@@ -69,10 +74,6 @@ public class YearMonthStream extends AbstractComparableStream<YearMonth> {
         return new YearMonthStream(from);
     }
 
-    private YearMonthStream(final YearMonth from) {
-        super(from);
-    }
-
     /**
      * Set the inclusive end point of the stream, using an absolute YearMonth.
      *
@@ -88,7 +89,7 @@ public class YearMonthStream extends AbstractComparableStream<YearMonth> {
      * Set the inclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in. May not be null.
+     * @param unit   The non-null unit the amount is denominated in. May not be null.
      * @return A non-null YearMonthStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -115,7 +116,7 @@ public class YearMonthStream extends AbstractComparableStream<YearMonth> {
      * Set the exclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null YearMonthStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -132,7 +133,7 @@ public class YearMonthStream extends AbstractComparableStream<YearMonth> {
      * for this builder is 1 Month.
      *
      * @param amount The number of units to use when calculating the next element of the stream.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null YearMonthStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -142,6 +143,22 @@ public class YearMonthStream extends AbstractComparableStream<YearMonth> {
         Objects.requireNonNull(unit);
         this.amount = Math.abs(amount);
         this.unit = unit;
+        YearMonth.now().plus(0, unit); // Fail fast test
+        return this;
+    }
+
+    /**
+     * Set the duration between successive elements produced by the stream. The default
+     * for this builder is 1 Month.
+     *
+     * @return A non-null YearMonthStream.
+     * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
+     * @see ChronoUnit
+     */
+    public YearMonthStream every(Period period) {
+        Objects.requireNonNull(unit);
+        this.unit = ChronoUnit.MONTHS;
+        this.amount = period.get(this.unit);
         YearMonth.now().plus(0, unit); // Fail fast test
         return this;
     }

--- a/src/main/java/com/ginsberg/timestream/ZonedDateTimeStream.java
+++ b/src/main/java/com/ginsberg/timestream/ZonedDateTimeStream.java
@@ -24,6 +24,7 @@
 
 package com.ginsberg.timestream;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
@@ -31,7 +32,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * A builder that creates a stream of ZonedDateTime objects.
- *
+ * <p>
  * <pre>
  * {@code
  * // Print all of the ZonedDateTimes between now and a day from now, every other minute.
@@ -47,8 +48,12 @@ import java.util.function.UnaryOperator;
  * @author Todd Ginsberg (todd@ginsberg.com)
  */
 public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime> {
-    private int amount = 1;
+    private long amount = 1;
     private ChronoUnit unit = ChronoUnit.SECONDS;
+
+    private ZonedDateTimeStream(final ZonedDateTime from) {
+        super(from);
+    }
 
     /**
      * Create a ZonedDateTimeStream, starting at ZonedDateTime.now().
@@ -69,10 +74,6 @@ public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime>
         return new ZonedDateTimeStream(from);
     }
 
-    private ZonedDateTimeStream(final ZonedDateTime from) {
-        super(from);
-    }
-
     /**
      * Set the inclusive end point of the stream, using an absolute ZonedDateTime.
      *
@@ -88,7 +89,7 @@ public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime>
      * Set the inclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in. May not be null.
+     * @param unit   The non-null unit the amount is denominated in. May not be null.
      * @return A non-null ZonedDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -115,7 +116,7 @@ public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime>
      * Set the exclusive end point of the stream, using a relative duration.
      *
      * @param amount The number of units to use when calculating the duration of the stream. May be negative.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null ZonedDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -132,7 +133,7 @@ public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime>
      * for this builder is 1 Second.
      *
      * @param amount The number of units to use when calculating the next element of the stream.
-     * @param unit The non-null unit the amount is denominated in.
+     * @param unit   The non-null unit the amount is denominated in.
      * @return A non-null ZonedDateTimeStream.
      * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
      * @see ChronoUnit
@@ -142,6 +143,22 @@ public class ZonedDateTimeStream extends AbstractComparableStream<ZonedDateTime>
         Objects.requireNonNull(unit);
         this.amount = Math.abs(amount);
         this.unit = unit;
+        return this;
+    }
+
+    /**
+     * Set the duration between successive elements produced by the stream. The default
+     * for this builder is 1 Second.
+     *
+
+     * @return A non-null ZonedDateTimeStream.
+     * @throws java.time.temporal.UnsupportedTemporalTypeException if the unit is not supported.
+     * @see ChronoUnit
+     */
+    public ZonedDateTimeStream every(Duration duration) {
+        Objects.requireNonNull(unit);
+        this.unit = ChronoUnit.SECONDS;
+        this.amount = duration.get(this.unit);
         return this;
     }
 

--- a/src/test/java/com/ginsberg/timestream/LocalDateStreamTest.java
+++ b/src/test/java/com/ginsberg/timestream/LocalDateStreamTest.java
@@ -28,6 +28,7 @@ import org.assertj.core.util.Sets;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -38,11 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LocalDateStreamTest {
 
+    final LocalDate now = LocalDate.now();
     private final Set<ChronoUnit> validChronoUnits = Sets.newLinkedHashSet(ChronoUnit.DAYS, ChronoUnit.WEEKS,
             ChronoUnit.MONTHS, ChronoUnit.YEARS, ChronoUnit.DECADES, ChronoUnit.CENTURIES,
             ChronoUnit.ERAS, ChronoUnit.MILLENNIA);
-
-    final LocalDate now = LocalDate.now();
 
     @Test
     public void stopsBeforeUntilDateGivenByChronoUnits() {
@@ -121,7 +121,7 @@ public class LocalDateStreamTest {
                 .limit(iterations);
         assertThat(stream)
                 .isNotNull()
-                .endsWith(now.plus(iterations-1, ChronoUnit.DAYS))
+                .endsWith(now.plus(iterations - 1, ChronoUnit.DAYS))
                 .hasSize(iterations);
     }
 
@@ -134,6 +134,19 @@ public class LocalDateStreamTest {
         assertThat(stream)
                 .isNotNull()
                 .containsExactly(now, now.minusDays(1), now.minusDays(2));
+    }
+
+    @Test
+    public void stopsBeforeToWhenEveryPeriodIsAfterEndDate() {
+        final Period period = Period.parse("P15D");
+        final Stream<LocalDate> stream = LocalDateStream
+                .from(now)
+                .until(now.plusMonths(1))
+                .every(period)
+                .stream();
+        assertThat(stream)
+                .isNotNull()
+                .containsExactly(now, now.plusDays(15));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/com/ginsberg/timestream/LocalDateTimeStreamTest.java
+++ b/src/test/java/com/ginsberg/timestream/LocalDateTimeStreamTest.java
@@ -26,6 +26,7 @@ package com.ginsberg.timestream;
 
 import org.junit.Test;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
@@ -113,7 +114,7 @@ public class LocalDateTimeStreamTest {
                 .limit(iterations);
         assertThat(stream)
                 .isNotNull()
-                .endsWith(now.plus(iterations-1, ChronoUnit.SECONDS))
+                .endsWith(now.plus(iterations - 1, ChronoUnit.SECONDS))
                 .hasSize(iterations);
     }
 
@@ -126,6 +127,19 @@ public class LocalDateTimeStreamTest {
         assertThat(stream)
                 .isNotNull()
                 .containsExactly(now, now.minusSeconds(1), now.minusSeconds(2));
+    }
+
+    @Test
+    public void stopsBeforeToWhenEveryDurationIsAfterEndDate() {
+        final Duration duration = Duration.parse("PT2S");
+        final Stream<LocalDateTime> stream = LocalDateTimeStream
+                .from(now)
+                .to(3, ChronoUnit.SECONDS)
+                .every(duration)
+                .stream();
+        assertThat(stream)
+                .isNotNull()
+                .containsExactly(now, now.plusSeconds(2));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/com/ginsberg/timestream/YearMonthStreamTest.java
+++ b/src/test/java/com/ginsberg/timestream/YearMonthStreamTest.java
@@ -27,6 +27,7 @@ package com.ginsberg.timestream;
 import org.assertj.core.util.Sets;
 import org.junit.Test;
 
+import java.time.Period;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -38,10 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class YearMonthStreamTest {
 
+    final YearMonth now = YearMonth.now();
     private final Set<ChronoUnit> validChronoUnits = Sets.newLinkedHashSet(ChronoUnit.MONTHS, ChronoUnit.YEARS,
             ChronoUnit.DECADES, ChronoUnit.CENTURIES, ChronoUnit.ERAS, ChronoUnit.MILLENNIA);
-
-    final YearMonth now = YearMonth.now();
 
     @Test
     public void stopsBeforeUntilDateGivenByChronoUnits() {
@@ -120,7 +120,7 @@ public class YearMonthStreamTest {
                 .limit(iterations);
         assertThat(stream)
                 .isNotNull()
-                .endsWith(now.plus(iterations-1, ChronoUnit.MONTHS))
+                .endsWith(now.plus(iterations - 1, ChronoUnit.MONTHS))
                 .hasSize(iterations);
     }
 
@@ -133,6 +133,19 @@ public class YearMonthStreamTest {
         assertThat(stream)
                 .isNotNull()
                 .containsExactly(now, now.minusMonths(1), now.minusMonths(2));
+    }
+
+    @Test
+    public void stopsBeforeToWhenEveryDurationIsAfterEndDate() {
+        final Period period = Period.parse("P2M");
+        final Stream<YearMonth> stream = YearMonthStream
+                .from(now)
+                .to(3, ChronoUnit.MONTHS)
+                .every(period)
+                .stream();
+        assertThat(stream)
+                .isNotNull()
+                .containsExactly(now, now.plusMonths(2));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/com/ginsberg/timestream/ZonedDateTimeStreamTest.java
+++ b/src/test/java/com/ginsberg/timestream/ZonedDateTimeStreamTest.java
@@ -26,6 +26,7 @@ package com.ginsberg.timestream;
 
 import org.junit.Test;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
@@ -113,7 +114,7 @@ public class ZonedDateTimeStreamTest {
                 .limit(iterations);
         assertThat(stream)
                 .isNotNull()
-                .endsWith(now.plus(iterations-1, ChronoUnit.SECONDS))
+                .endsWith(now.plus(iterations - 1, ChronoUnit.SECONDS))
                 .hasSize(iterations);
     }
 
@@ -126,6 +127,19 @@ public class ZonedDateTimeStreamTest {
         assertThat(stream)
                 .isNotNull()
                 .containsExactly(now, now.minusSeconds(1), now.minusSeconds(2));
+    }
+
+    @Test
+    public void stopsBeforeToWhenEveryDurationIsAfterEndDate() {
+        final Duration duration = Duration.parse("PT2S");
+        final Stream<ZonedDateTime> stream = ZonedDateTimeStream
+                .from(now)
+                .to(3, ChronoUnit.SECONDS)
+                .every(duration)
+                .stream();
+        assertThat(stream)
+                .isNotNull()
+                .containsExactly(now, now.plusSeconds(2));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Add new signature for the every() methods, that take TemporalAmount (Period or Duration) as parameter.

